### PR TITLE
Upload HDF5 Java source

### DIFF
--- a/.github/workflows/build-java-macos.yml
+++ b/.github/workflows/build-java-macos.yml
@@ -51,3 +51,7 @@ jobs:
           name: hdf5-build-macos
           path: dist/
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: hdf5-java-source
+          path: dist-src

--- a/releng/build_macos_bindings.sh
+++ b/releng/build_macos_bindings.sh
@@ -7,7 +7,9 @@ fi
 if [ -z "$DEST_DIR" ]; then
     export DEST_DIR="$PWD/dist"
 fi
-
+if [ -z "$JAVA_SRC_OUTPUT_DIR" ]; then
+    export JAVA_SRC_OUTPUT_DIR="$PWD/dist-src"
+fi
 if [ -z "$CROSS_BUILD" ]; then
     CROSS_BUILD=n
 fi
@@ -147,3 +149,5 @@ else
     otool -L $B_DEST/*.dylib
 fi
 
+# Copy Java source to be archived
+cp -a ${HDF5_SRC}/java/src ${JAVA_SRC_OUTPUT_DIR}/


### PR DESCRIPTION
Attach (patched) Java source as an artifact. This is to allow it to be consumed by other jobs.

Any of the different OS workflows could be used but for simplicity just use the linux workflow.